### PR TITLE
Fixed an issue where RuntimeError was thrown when running multiple tests

### DIFF
--- a/aiounittest/helpers.py
+++ b/aiounittest/helpers.py
@@ -114,9 +114,13 @@ def run_sync(func=None, loop=None):
 
     '''
     def get_brand_new_default_event_loop():
-        old_loop = asyncio.get_event_loop()
-        if not old_loop.is_closed():
-            old_loop.close()
+        try:
+            old_loop = asyncio.get_event_loop()
+            if not old_loop.is_closed():
+                old_loop.close()
+        except RuntimeError:
+            # no default event loop, ignore exception
+            pass
         _loop = asyncio.new_event_loop()
         asyncio.set_event_loop(_loop)
         return _loop


### PR DESCRIPTION
Fixes issue #10:
RuntimeError was thrown the decorator trying to get the default event
loop after the old event loop was closed. No default event loop existed
and the asyncio threw a RuntimeErroe exception.