### PR TITLE
Fix typo in documentation

### DIFF
--- a/aiounittest/helpers.py
+++ b/aiounittest/helpers.py
@@ -86,7 +86,7 @@ def run_sync(func=None, loop=None):
 
     **Note**: :code:`aiounittest.async_test` is an alias of :code:`aiounittest.helpers.run_sync`
 
-    Function can be used like a `pytest.mark.asyncio` (implemetation differs),
+    Function can be used like a `pytest.mark.asyncio` (implementation differs),
     but it's compatible with :code:`unittest.TestCase` class.
 
     .. code-block:: python


### PR DESCRIPTION
Small typo fix in the docs