### PR TITLE
Re-export top-level imports to satisfy Mypy

### DIFF
--- a/aiounittest/__init__.py
+++ b/aiounittest/__init__.py
@@ -1,2 +1,9 @@
 from .case import AsyncTestCase
 from .helpers import futurized, run_sync, async_test
+
+__all__ = [
+    "AsyncTestCase",
+    "futurized",
+    "run_sync",
+    "async_test"
+]


### PR DESCRIPTION
Using Mypy (at least in strict mode) with the library as it currently is causes errors.

```python
import aiounittest


class ExampleTest(aiounittest.AsyncTestCase):
    def test_example(self) -> None:
        self.assertEqual(1, 2 - 1)
```


```
tests/test_example.py:4: error: Name "aiounittest.AsyncTestCase" is not defined
tests/test_example.py:4: error: Class cannot subclass "AsyncTestCase" (has type "Any")
```

It seems to be good practice to 're-export' (using `__all__`) all the things that you import into a module and wish to allow others to use as an import. I don't think this is actually functionally different, but just a convention.
IDEs (auto-import feature) and Mypy pick up on this, at the very least.


Signed-off-by: Olivier Wilkinson (reivilibre) <oliverw@matrix.org>
I am happy for these changes to be available under the project's licence (MIT).
