### PR TITLE
test_sync_async_add: After closing the default event loop, set a new one

### DIFF
--- a/tests/test_asynctestcase.py
+++ b/tests/test_asynctestcase.py
@@ -33,6 +33,9 @@ class TestAsyncCase(aiounittest.AsyncTestCase):
         loop.close()
         self.assertEqual(ret, 6)
 
+        # Set a new event loop, since we closed the old one
+        asyncio.set_event_loop(asyncio.new_event_loop())
+
     async def test_await_async_add(self):
         ret = await async_add(1, 5)
         self.assertEqual(ret, 6)


### PR DESCRIPTION
`TestAsyncCase.test_sync_async_add` leaves the default loop closed. If `TestAsyncCaseWithCustomLoop.test_await_async_add` runs *right* after it, it will fail.
As far as I can see from the other test methods, the default loop should be reset if it's closed.

Usually, this issue is masked by tests that run in between these two and re-set the default event loop as a side effect. It can be reproduced with `pytest -k 'test_await_async_add or test_sync_async_add'`, or on Python 3.11 with #21 merged (cc @hroncok).