### PR TITLE
include requirements.txt and tests in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,5 +3,7 @@ include LICENSE
 include aiounittest/py.typed
 include requirements.txt
 
+recursive-include tests *.py
+
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include README.rst
 include LICENSE
 include aiounittest/py.typed
+include requirements.txt
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]


### PR DESCRIPTION
Congrats on 1.4.3!

This PR ensures `requirements.txt` is included in this `sdist`, which presently fails to install with:

```
  FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
```

Additionally it adds the tests to the `sdist` such that the canonical source can be used to validate an as-installed package.