### PR TITLE
Use inspect for coroutine function checks

### DIFF
--- a/aiounittest/case.py
+++ b/aiounittest/case.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import unittest
 from .helpers import async_test
 
@@ -79,7 +80,7 @@ class AsyncTestCase(unittest.TestCase):
 
     def __getattribute__(self, name):
         attr = super().__getattribute__(name)
-        if name.startswith('test_') and asyncio.iscoroutinefunction(attr):
+        if name.startswith('test_') and inspect.iscoroutinefunction(attr):
             return async_test(attr, loop=self.get_event_loop())
         else:
             return attr


### PR DESCRIPTION
Fixes #30.

## Summary
- replace deprecated `asyncio.iscoroutinefunction()` with `inspect.iscoroutinefunction()` in `AsyncTestCase.__getattribute__`
- keep the existing async test wrapping behavior while avoiding the Python 3.14 deprecation warning and planned Python 3.16 removal

## Validation
- Not run locally
- `git diff --check HEAD~1..HEAD`
- Remote PR workflow is currently awaiting approval